### PR TITLE
Update timeouts.js

### DIFF
--- a/lib/server/controllers/timeouts.js
+++ b/lib/server/controllers/timeouts.js
@@ -3,7 +3,7 @@
 function *implicitWait(next) {
   const body = this.request.body;
   const ms = body.ms;
-  this.implicitWaitMs = parseInt(ms, 10);
+  this.device.implicitWaitMs = parseInt(ms, 10);
   this.state.value = null;
   yield next;
 }


### PR DESCRIPTION
fix the issue where `implicitWaitMs` field is not passed to the device instance

https://github.com/search?q=org%3Amacacajs+implicitWaitMs&type=code

```js
// webdriver-server lib/server/controllers/session.js
const detectDevice = function(desiredCapabilities) {
      // ...
      let Driver = require(`macaca-${browserName}`);
      return new Driver();
      // ...
}
const device = detectDevice(caps);
return device;
```


```js
// macaca-electron lib/controllers.js
const implicitWaitForCondition = function (func) {
  return _.waitForCondition(func, this.implicitWaitMs);
};

const findElementOrElements = async function (strategy, selector, ctx, many) {
  let result;
  const that = this;
  // ...
  try {
    await implicitWaitForCondition.call(this, co.wrap(search));
  } catch (err) {
    result = [];
  }

  // ...
};

controllers.findElement = async function (strategy, selector, ctx) {
  return await findElementOrElements.call(this, strategy, selector, ctx, false);
};

```

```js
// macaca-electron lib/macaca-electron.js
const controllers = require('./controllers');
class Electron extends DriverBase {
}

_.extend(Electron.prototype, controllers);

module.exports = Electron;
```

How to use:
```js
// in test code
driver
      .setImplicitWaitTimeout(1000)
      // ...
```